### PR TITLE
Add max tokens to domain model, change field order

### DIFF
--- a/lute/book/forms.py
+++ b/lute/book/forms.py
@@ -46,8 +46,8 @@ class NewBookForm(FlaskForm):
     )
     book_tags = StringField("Tags")
     max_page_tokens = IntegerField(
-        "Words per page(include punctuations)",
-        validators=[NumberRange(min=200, max=1500)],
+        "Words per page",
+        validators=[NumberRange(min=10, max=1500)],
         default=250,
     )
 

--- a/lute/book/forms.py
+++ b/lute/book/forms.py
@@ -34,6 +34,11 @@ class NewBookForm(FlaskForm):
             )
         ],
     )
+    max_page_tokens = IntegerField(
+        "Words per page",
+        validators=[NumberRange(min=10, max=1500)],
+        default=250,
+    )
     source_uri = StringField("Text source", validators=[Length(max=255)])
     audiofile = FileField(
         "Audio file",
@@ -45,11 +50,6 @@ class NewBookForm(FlaskForm):
         ],
     )
     book_tags = StringField("Tags")
-    max_page_tokens = IntegerField(
-        "Words per page",
-        validators=[NumberRange(min=10, max=1500)],
-        default=250,
-    )
 
     def __init__(self, *args, **kwargs):
         "Call the constructor of the superclass (FlaskForm)"

--- a/lute/book/model.py
+++ b/lute/book/model.py
@@ -16,6 +16,7 @@ class Book:  # pylint: disable=too-many-instance-attributes
         self.language_id = None
         self.title = None
         self.text = None
+        self.max_page_tokens = 250
         self.source_uri = None
         self.audio_filename = None
         self.audio_current_pos = None
@@ -49,13 +50,13 @@ class Repository:
         bts = self.db.session.query(BookTag).all()
         return [t.text for t in bts]
 
-    def add(self, book, max_word_tokens_per_text=250):
+    def add(self, book):
         """
         Add a book to be saved to the db session.
         Returns DBBook for tests and verification only,
         clients should not change it.
         """
-        dbbook = self._build_db_book(book, max_word_tokens_per_text)
+        dbbook = self._build_db_book(book)
         self.db.session.add(dbbook)
         return dbbook
 
@@ -74,16 +75,14 @@ class Repository:
         """
         self.db.session.commit()
 
-    def _build_db_book(self, book, max_word_tokens_per_text):
+    def _build_db_book(self, book):
         "Convert a book business object to a DBBook."
 
         lang = Language.find(book.language_id)
 
         b = None
         if book.id is None:
-            b = DBBook.create_book(
-                book.title, lang, book.text, max_word_tokens_per_text
-            )
+            b = DBBook.create_book(book.title, lang, book.text, book.max_page_tokens)
         else:
             b = DBBook.find(book.id)
         b.title = book.title

--- a/lute/book/routes.py
+++ b/lute/book/routes.py
@@ -103,8 +103,7 @@ def new():
             f = form.audiofile.data
             if f:
                 b.audio_filename = service.save_audio_file(f)
-            max_page_tokens = form.max_page_tokens.data
-            book = repo.add(b, max_page_tokens)
+            book = repo.add(b)
             repo.commit()
             return redirect(f"/read/{book.id}/page/1", 302)
         except service.BookImportException as e:

--- a/lute/templates/book/create_new.html
+++ b/lute/templates/book/create_new.html
@@ -38,6 +38,11 @@
     </tr>
 
     <tr>
+        <td> {{ form.max_page_tokens.label }}</td>
+        <td> {{ form.max_page_tokens(class="form-control") }}</td>
+    </tr>
+
+    <tr>
       <td>{{ form.source_uri.label }}</td>
       <td>{{ form.source_uri(class="form-control") }}</td>
     </tr>
@@ -50,10 +55,6 @@
     <tr>
       <td>{{ form.book_tags.label }}</td>
       <td>{{ form.book_tags(class="form-control") }}</td>
-    </tr>
-    <tr>
-        <td> {{ form.max_page_tokens.label }}</td>
-        <td> {{ form.max_page_tokens(class="form-control") }}</td>
     </tr>
 
   </tbody>

--- a/tests/unit/book/test_Repository.py
+++ b/tests/unit/book/test_Repository.py
@@ -49,6 +49,30 @@ def test_save_new(app_context, new_book, repo):
     assert book.book_tags == ["tag1", "tag2"], "tags filled"
 
 
+def test_save_new_respects_book_words_per_page_count(app_context, new_book, repo):
+    """
+    Saving a simple Book object loads the database.
+    """
+    sql = "select BkTitle from books where BkTitle = 'HELLO'"
+    assert_sql_result(sql, [], "empty table")
+
+    new_book.max_page_tokens = 10
+    new_book.text = (
+        "One two three four. One two three four five six seven eight nine ten eleven."
+    )
+    b = repo.add(new_book)
+    repo.commit()
+    assert_sql_result(sql, ["HELLO"], "Saved")
+    assert b.texts[0].text == "One two three four.", "page 1"
+    assert (
+        b.texts[1].text == "One two three four five six seven eight nine ten eleven."
+    ), "page 2"
+
+    book = repo.load(b.id)
+    assert book.title == new_book.title, "found book"
+    assert book.book_tags == ["tag1", "tag2"], "tags filled"
+
+
 def test_get_tags(app_context, new_book, repo):
     "Helper method test."
     assert repo.get_book_tags() == [], "no tags yet"


### PR DESCRIPTION
Small differences.

Words per page moved in form:

> <img width="1279" alt="image" src="https://github.com/fanyingfx/lute-v3/assets/1637133/debad8a3-3cf1-41ad-92c1-41aefee3eca8">

Added max tokens to the domain model, just means less special handling for that new field.  Added a test for completeness.

